### PR TITLE
Add back the 'video_shader' parameter.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1514,6 +1514,8 @@ static struct config_path_setting *populate_settings_path(
          settings->paths.directory_resampler, false, NULL, true);
    SETTING_PATH("video_shader_dir",
          settings->paths.directory_video_shader, true, NULL, true);
+   SETTING_PATH("video_shader",
+         settings->paths.path_shader, false, NULL, true);
    SETTING_PATH("video_filter_dir",
          settings->paths.directory_video_filter, true, NULL, true);
    SETTING_PATH("core_assets_directory",
@@ -2667,6 +2669,7 @@ void config_set_defaults(void *data)
    *settings->paths.directory_menu_config = '\0';
 #endif
    *settings->paths.directory_video_shader = '\0';
+   *settings->paths.path_shader = '\0';
    *settings->paths.directory_video_filter = '\0';
    *settings->paths.directory_audio_filter = '\0';
 
@@ -4907,6 +4910,10 @@ bool config_save_overrides(enum override_type type, void *data)
 
       for (i = 0; i < (unsigned)path_settings_size; i++)
       {
+         /* blacklist 'video_shader', better handled by shader presets */
+         if (string_is_equal(path_settings[i].ident, "video_shader"))
+             continue;
+
          if (!string_is_equal(path_settings[i].ptr, path_overrides[i].ptr))
             config_set_path(conf, path_overrides[i].ident,
                   path_overrides[i].ptr);

--- a/configuration.h
+++ b/configuration.h
@@ -485,6 +485,7 @@ typedef struct settings
       char path_cheat_settings[PATH_MAX_LENGTH];
       char path_font[PATH_MAX_LENGTH];
       char path_rgui_theme_preset[PATH_MAX_LENGTH];
+      char path_shader[PATH_MAX_LENGTH];
 
       char directory_audio_filter[PATH_MAX_LENGTH];
       char directory_autoconfig[PATH_MAX_LENGTH];

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -2313,9 +2313,10 @@ static bool retroarch_load_shader_preset_internal(
       {
          if (string_is_empty(special_name))
             break;
-
-         fill_pathname_join(s, shader_directory, special_name, len);
-         strlcat(s, video_shader_get_preset_extension(types[i]), len);
+         if (strcmp(special_name, "config")!=0) {
+            fill_pathname_join(s, shader_directory, special_name, len);
+            strlcat(s, video_shader_get_preset_extension(types[i]), len);
+         }
       }
 
       if (path_is_valid(s))
@@ -2397,6 +2398,17 @@ bool load_shader_preset(settings_t *settings, const char *core_name,
                sizeof(shader_path),
                dirs[i], NULL,
                "global"))
+         goto success;
+   }
+   /* Configuration file shader found ? */
+   strlcpy(shader_path, settings->paths.path_shader, PATH_MAX_LENGTH);
+   if (!string_is_empty(shader_path)) {
+      RARCH_LOG("[Shaders/RetroPie]: Configuration file shader path found.\n");
+      if(retroarch_load_shader_preset_internal(
+            shader_path,
+            sizeof(shader_path),
+            NULL, NULL,
+            "config"))
          goto success;
    }
    return false;


### PR DESCRIPTION
The `video_shader` configuration parameter has been removed from RetroArch a while ago,
in favour of per-game/core/folder shader overrides.

However, the built-in shader override mechanism depends on the core name used, while `video_shader`
can be used without any core (name) dependency, which makes it easier to configure with the RetroPie
configuration editor.

The patch will load the shader preset specified in the `video_shader` path if none of the built-in shader
overrides have not been found. The parameter is not saved as part of any override/configuration file when
saving is done from RetroArch's menu, the only mechanism to set it is by directly editing the conf file or via the configuration editor.

