### PR TITLE
intl: fix crash with Korean language

### DIFF
--- a/intl/msg_hash_ko.h
+++ b/intl/msg_hash_ko.h
@@ -13387,7 +13387,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_DEVICE_CONFIGURED_IN_PORT_NR,
-   "%u 포트에 %s 구성됨"
+      "%s가 포트 %u에 구성됨"
    )
 MSG_HASH(
    MSG_DEVICE_DISCONNECTED_FROM_PORT,


### PR DESCRIPTION
Cherry-picked manually from https://github.com/libretro/RetroArch/commit/5e3161ea3c8966896519c79162ab974abb2364cd. See https://github.com/libretro/RetroArch/issues/15229, which is a bit misleading since it's not really Xinput related.
